### PR TITLE
Change xor function to :erlang.bxor

### DIFF
--- a/lib/kademlia/node.ex
+++ b/lib/kademlia/node.ex
@@ -50,7 +50,7 @@ defmodule Kademlia.Node do
 
     id_tuple
     |> Enum.map(fn {bin1, bin2} ->
-      bin1 ^^^ bin2
+      :erlang.bxor(bin1, bin2)
     end)
     |> :binary.list_to_bin
   end


### PR DESCRIPTION
There doesn't seem to be a performance degradation when I change the xor distance check. The original didn't work when I tried it in iex.
